### PR TITLE
Corrijo llamada a L.latLng

### DIFF
--- a/Leaflet.CheapLayerAt.js
+++ b/Leaflet.CheapLayerAt.js
@@ -2,7 +2,7 @@
 L.Map.include({
 
 	getLayerAtLatLng: function(latlng, lng) {
-		latlng = L.latlng(latlng, lng);
+		latlng = L.latLng(latlng, lng);
 
 		return this.layerAt(latLngToContainerPoint(latlng));
 	},


### PR DESCRIPTION
la llamada a L.latLng no está escrita en Camel Case, da error al ejecutarse.
